### PR TITLE
Add level display and refine UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ npm run dev
 - After clearing a level, press **NEXT LEVEL** to advance.
 - The **RESET** button appears only after a game over to restart the current level.
 - Level 5 is labeled as the final stage.
+- After clearing the final stage, press **Play Again!!** to restart from level 1.

--- a/src/App.css
+++ b/src/App.css
@@ -63,3 +63,9 @@
   color: #333;
   margin-top: 1rem;
 }
+
+.play-again {
+  font-size: 1.25rem;
+  padding: 0.8rem 1.6rem;
+  background: linear-gradient(135deg, #42e695 0%, #3bb2b8 100%);
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,7 +123,14 @@ function App() {
       </div>
       <div className="buttons">
         {state === 'lost' && <button onClick={reset}>RESET</button>}
-        {state === 'won' && <button onClick={nextLevel}>NEXT LEVEL</button>}
+        {state === 'won' &&
+          (level === LEVELS.length - 1 ? (
+            <button className="play-again" onClick={nextLevel}>
+              Play Again!!
+            </button>
+          ) : (
+            <button onClick={nextLevel}>NEXT LEVEL</button>
+          ))}
       </div>
       {state === 'won' && (
         <p className="clear-message">


### PR DESCRIPTION
## Summary
- show current level in the game screen
- show a bigger message when a level is cleared
- only show the reset button after game over
- document new reset button behavior

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841a26140f0832c91aeac37d466ff1d