### PR TITLE
Add test mode with guaranteed clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ npm run dev
 - The **RESET** button appears only after a game over to restart the current level.
 - Level 5 is labeled as the final stage.
 - After clearing the final stage, press **Play Again!!** to restart from level 1.
+- Add `?test=true` to the URL for a mode where the first opened cell is always safe.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ const LEVELS = [
 ]
 
 function App() {
+  const isTest = new URLSearchParams(window.location.search).get('test') === 'true'
   const [level, setLevel] = useState(0)
   const [board, setBoard] = useState<CellState[][]>([])
   const [safePos, setSafePos] = useState<[number, number]>([0, 0])
@@ -62,14 +63,16 @@ function App() {
     const cell = newBoard[y][x]
     if (cell.opened || cell.flagged) return
     cell.opened = true
+    const targetSafe: [number, number] = isTest ? [x, y] : safePos
 
-    if (x === safePos[0] && y === safePos[1]) {
+    if (x === targetSafe[0] && y === targetSafe[1]) {
+      if (isTest) setSafePos(targetSafe)
       setState('won')
     } else {
       setState('lost')
       for (let j = 0; j < height; j++) {
         for (let i = 0; i < width; i++) {
-          if (!(i === safePos[0] && j === safePos[1])) {
+          if (!(i === targetSafe[0] && j === targetSafe[1])) {
             newBoard[j][i].opened = true
           }
         }


### PR DESCRIPTION
## Summary
- add a `test=true` query param option that forces the first opened cell to be safe
- document the test mode in the README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841a64d1fcc832c82918f2d3eb7b3fc