### PR TITLE
Show final clear message over board

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,6 +15,11 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 
+.board-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
 .cell {
   width: 40px;
   height: 40px;
@@ -56,6 +61,18 @@
   font-size: 2rem;
   color: #ff5f6d;
   margin-top: 1rem;
+}
+
+.clear-message.overlay {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  margin-top: 0;
+  padding: 0.5rem 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 8px;
+  pointer-events: none;
 }
 
 .game-over {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,27 +101,32 @@ function App() {
         Level {level + 1}
         {level === LEVELS.length - 1 && ' (Final Stage)'}
       </p>
-      <div
-        className="board"
-        style={{ gridTemplateColumns: `repeat(${width}, 40px)` }}
-      >
-        {board.map((row, y) =>
-          row.map((cell, x) => (
-            <div
-              key={`${x}-${y}`}
-              className={`cell${cell.opened ? ' opened' : ''}`}
-              onClick={() => open(x, y)}
-              onContextMenu={(e) => toggleFlag(e, x, y)}
-            >
-              {cell.opened
-                ? x === safePos[0] && y === safePos[1]
-                  ? countAdjacent(x, y) || ''
-                  : '💣'
-                : cell.flagged
-                ? '⚑'
-                : ''}
-            </div>
-          )),
+      <div className="board-wrapper">
+        <div
+          className="board"
+          style={{ gridTemplateColumns: `repeat(${width}, 40px)` }}
+        >
+          {board.map((row, y) =>
+            row.map((cell, x) => (
+              <div
+                key={`${x}-${y}`}
+                className={`cell${cell.opened ? ' opened' : ''}`}
+                onClick={() => open(x, y)}
+                onContextMenu={(e) => toggleFlag(e, x, y)}
+              >
+                {cell.opened
+                  ? x === safePos[0] && y === safePos[1]
+                    ? countAdjacent(x, y) || ''
+                    : '💣'
+                  : cell.flagged
+                  ? '⚑'
+                  : ''}
+              </div>
+            )),
+          )}
+        </div>
+        {state === 'won' && level === LEVELS.length - 1 && (
+          <p className="clear-message overlay">All Levels Cleared!</p>
         )}
       </div>
       <div className="buttons">
@@ -135,12 +140,8 @@ function App() {
             <button onClick={nextLevel}>NEXT LEVEL</button>
           ))}
       </div>
-      {state === 'won' && (
-        <p className="clear-message">
-          {level === LEVELS.length - 1
-            ? 'All Levels Cleared!'
-            : `Level ${level + 1} Clear!`}
-        </p>
+      {state === 'won' && level !== LEVELS.length - 1 && (
+        <p className="clear-message">Level {level + 1} Clear!</p>
       )}
       {state === 'lost' && <p className="game-over">Game Over</p>}
     </div>


### PR DESCRIPTION
## Summary
- overlay the "All Levels Cleared" message over the grid when clearing the final level
- show normal level clear message only for other stages
- add board wrapper and overlay styles

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842cd0f74c8832cb228db547c05f729